### PR TITLE
added batchSender config for gps transport

### DIFF
--- a/Transport/GpsBatchSender.php
+++ b/Transport/GpsBatchSender.php
@@ -35,7 +35,7 @@ final class GpsBatchSender implements SenderInterface
         $this->gpsConfiguration = $gpsConfiguration;
         $this->serializer = $serializer;
 
-        $batchOptions = $this->gpsConfiguration->getBatchOptions();
+        $batchOptions = $this->gpsConfiguration->getBatchSenderOptions();
         $this->batchOptions['batchSize'] = $batchOptions['batchSize'] ?? $this->batchOptions['batchSize'];
         $this->batchOptions['callPeriod'] = $batchOptions['callPeriod'] ?? $this->batchOptions['callPeriod'];
     }

--- a/Transport/GpsBatchSender.php
+++ b/Transport/GpsBatchSender.php
@@ -34,6 +34,10 @@ final class GpsBatchSender implements SenderInterface
         $this->pubSubClient = $pubSubClient;
         $this->gpsConfiguration = $gpsConfiguration;
         $this->serializer = $serializer;
+
+        $batchOptions = $this->gpsConfiguration->getBatchOptions();
+        $this->batchOptions['batchSize'] = $batchOptions['batchSize'] ?? $this->batchOptions['batchSize'];
+        $this->batchOptions['callPeriod'] = $batchOptions['callPeriod'] ?? $this->batchOptions['callPeriod'];
     }
 
     public function send(Envelope $envelope): Envelope

--- a/Transport/GpsConfiguration.php
+++ b/Transport/GpsConfiguration.php
@@ -16,6 +16,7 @@ final class GpsConfiguration implements GpsConfigurationInterface
     private array $topicOptions;
     private array $subscriptionOptions;
     private array $subscriptionPullOptions;
+    private array $batchOptions;
 
     public function __construct(
         string $queueName,
@@ -24,7 +25,8 @@ final class GpsConfiguration implements GpsConfigurationInterface
         array $clientConfig,
         array $topicOptions,
         array $subscriptionOptions,
-        array $subscriptionPullOptions
+        array $subscriptionPullOptions,
+        array $batchOptions
     ) {
         $this->topicName = $queueName;
         $this->subscriptionName = $subscriptionName;
@@ -33,6 +35,7 @@ final class GpsConfiguration implements GpsConfigurationInterface
         $this->topicOptions = $topicOptions;
         $this->subscriptionOptions = $subscriptionOptions;
         $this->subscriptionPullOptions = $subscriptionPullOptions;
+        $this->batchOptions = $batchOptions;
     }
 
     public function getTopicName(): string
@@ -68,5 +71,15 @@ final class GpsConfiguration implements GpsConfigurationInterface
     public function getSubscriptionPullOptions(): array
     {
         return $this->subscriptionPullOptions;
+    }
+
+    public function getBatchOptions(): array
+    {
+        return $this->batchOptions;
+    }
+
+    public function isBatchingEnabled(): bool
+    {
+        return $this->batchOptions['enabled'] ?? true;
     }
 }

--- a/Transport/GpsConfiguration.php
+++ b/Transport/GpsConfiguration.php
@@ -16,7 +16,7 @@ final class GpsConfiguration implements GpsConfigurationInterface
     private array $topicOptions;
     private array $subscriptionOptions;
     private array $subscriptionPullOptions;
-    private array $batchOptions;
+    private array $batchSenderOptions;
 
     public function __construct(
         string $queueName,
@@ -26,7 +26,7 @@ final class GpsConfiguration implements GpsConfigurationInterface
         array $topicOptions,
         array $subscriptionOptions,
         array $subscriptionPullOptions,
-        array $batchOptions
+        array $batchSenderOptions
     ) {
         $this->topicName = $queueName;
         $this->subscriptionName = $subscriptionName;
@@ -35,7 +35,7 @@ final class GpsConfiguration implements GpsConfigurationInterface
         $this->topicOptions = $topicOptions;
         $this->subscriptionOptions = $subscriptionOptions;
         $this->subscriptionPullOptions = $subscriptionPullOptions;
-        $this->batchOptions = $batchOptions;
+        $this->batchSenderOptions = $batchSenderOptions;
     }
 
     public function getTopicName(): string
@@ -73,13 +73,13 @@ final class GpsConfiguration implements GpsConfigurationInterface
         return $this->subscriptionPullOptions;
     }
 
-    public function getBatchOptions(): array
+    public function getBatchSenderOptions(): array
     {
-        return $this->batchOptions;
+        return $this->batchSenderOptions;
     }
 
-    public function isBatchingEnabled(): bool
+    public function isBatchSenderEnabled(): bool
     {
-        return $this->batchOptions['enabled'];
+        return $this->batchSenderOptions['enabled'];
     }
 }

--- a/Transport/GpsConfiguration.php
+++ b/Transport/GpsConfiguration.php
@@ -80,6 +80,6 @@ final class GpsConfiguration implements GpsConfigurationInterface
 
     public function isBatchingEnabled(): bool
     {
-        return $this->batchOptions['enabled'] ?? true;
+        return $this->batchOptions['enabled'];
     }
 }

--- a/Transport/GpsConfigurationInterface.php
+++ b/Transport/GpsConfigurationInterface.php
@@ -38,4 +38,8 @@ interface GpsConfigurationInterface
      * @see Subscription::pull options
      */
     public function getSubscriptionPullOptions(): array;
+
+    public function getBatchOptions(): array;
+
+    public function isBatchingEnabled(): bool;
 }

--- a/Transport/GpsConfigurationInterface.php
+++ b/Transport/GpsConfigurationInterface.php
@@ -39,7 +39,7 @@ interface GpsConfigurationInterface
      */
     public function getSubscriptionPullOptions(): array;
 
-    public function getBatchOptions(): array;
+    public function getBatchSenderOptions(): array;
 
-    public function isBatchingEnabled(): bool;
+    public function isBatchSenderEnabled(): bool;
 }

--- a/Transport/GpsConfigurationResolver.php
+++ b/Transport/GpsConfigurationResolver.php
@@ -13,6 +13,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 final class GpsConfigurationResolver implements GpsConfigurationResolverInterface
 {
     private const INT_NORMALIZER_KEY = 'int';
+    private const FLOAT_NORMALIZER_KEY = 'float';
     private const BOOL_NORMALIZER_KEY = 'bool';
     private const NORMALIZABLE_SUBSCRIPTION_OPTIONS = [
         self::INT_NORMALIZER_KEY => ['ackDeadlineSeconds', 'maxDeliveryAttempts'],
@@ -21,6 +22,11 @@ final class GpsConfigurationResolver implements GpsConfigurationResolverInterfac
     private const NORMALIZABLE_SUBSCRIPTION_PULL_OPTIONS = [
         self::INT_NORMALIZER_KEY => ['maxMessages'],
         self::BOOL_NORMALIZER_KEY => ['returnImmediately'],
+    ];
+    private const NORMALIZABLE_BATCH_OPTIONS = [
+        self::INT_NORMALIZER_KEY => ['batchSize'],
+        self::FLOAT_NORMALIZER_KEY => ['callPeriod'],
+        self::BOOL_NORMALIZER_KEY => ['enabled'],
     ];
 
     /**
@@ -53,6 +59,24 @@ final class GpsConfigurationResolver implements GpsConfigurationResolverInterfac
                         $data[$optionName] = (int) filter_var($optionValue, FILTER_SANITIZE_NUMBER_INT);
                         break;
                     case \in_array($optionName, self::NORMALIZABLE_SUBSCRIPTION_PULL_OPTIONS[self::BOOL_NORMALIZER_KEY], true):
+                        $data[$optionName] = filter_var($optionValue, FILTER_VALIDATE_BOOLEAN);
+                        break;
+                }
+            }
+
+            return $data;
+        };
+
+        $batchOptionsNormalizer = static function (Options $options, $data) {
+            foreach ($data ?? [] as $optionName => $optionValue) {
+                switch ($optionName) {
+                    case \in_array($optionName, self::NORMALIZABLE_BATCH_OPTIONS[self::INT_NORMALIZER_KEY], true):
+                        $data[$optionName] = (int) filter_var($optionValue, FILTER_SANITIZE_NUMBER_INT);
+                        break;
+                    case \in_array($optionName, self::NORMALIZABLE_BATCH_OPTIONS[self::FLOAT_NORMALIZER_KEY], true):
+                        $data[$optionName] = (float) filter_var($optionValue, FILTER_SANITIZE_NUMBER_FLOAT);
+                        break;
+                    case \in_array($optionName, self::NORMALIZABLE_BATCH_OPTIONS[self::BOOL_NORMALIZER_KEY], true):
                         $data[$optionName] = filter_var($optionValue, FILTER_VALIDATE_BOOLEAN);
                         break;
                 }
@@ -160,6 +184,9 @@ final class GpsConfigurationResolver implements GpsConfigurationResolverInterfac
             )
             ->setDefault('compress_message_body', false)
             ->setAllowedTypes('compress_message_body', 'bool')
+            ->setDefault('batch', [])
+            ->setAllowedTypes('batch', 'array')
+            ->setNormalizer('batch', $batchOptionsNormalizer)
             ->setAllowedTypes('client_config', 'array')
         ;
 
@@ -172,7 +199,8 @@ final class GpsConfigurationResolver implements GpsConfigurationResolverInterfac
             $resolvedOptions['client_config'],
             $resolvedOptions['topic']['options'],
             $resolvedOptions['subscription']['options'],
-            $resolvedOptions['subscription']['pull']
+            $resolvedOptions['subscription']['pull'],
+            $resolvedOptions['batch']
         );
     }
 

--- a/Transport/GpsConfigurationResolver.php
+++ b/Transport/GpsConfigurationResolver.php
@@ -67,7 +67,7 @@ final class GpsConfigurationResolver implements GpsConfigurationResolverInterfac
             return $data;
         };
 
-        $batchOptionsNormalizer = static function (Options $options, $data) {
+        $batchSenderOptionsNormalizer = static function (Options $options, $data) {
             foreach ($data ?? [] as $optionName => $optionValue) {
                 switch ($optionName) {
                     case \in_array($optionName, self::NORMALIZABLE_BATCH_OPTIONS[self::INT_NORMALIZER_KEY], true):
@@ -184,9 +184,9 @@ final class GpsConfigurationResolver implements GpsConfigurationResolverInterfac
             )
             ->setDefault('compress_message_body', false)
             ->setAllowedTypes('compress_message_body', 'bool')
-            ->setDefault('batch', ['enabled' => true])
-            ->setAllowedTypes('batch', 'array')
-            ->setNormalizer('batch', $batchOptionsNormalizer)
+            ->setDefault('batchSender', ['enabled' => true])
+            ->setAllowedTypes('batchSender', 'array')
+            ->setNormalizer('batchSender', $batchSenderOptionsNormalizer)
             ->setAllowedTypes('client_config', 'array')
         ;
 
@@ -200,7 +200,7 @@ final class GpsConfigurationResolver implements GpsConfigurationResolverInterfac
             $resolvedOptions['topic']['options'],
             $resolvedOptions['subscription']['options'],
             $resolvedOptions['subscription']['pull'],
-            $resolvedOptions['batch']
+            $resolvedOptions['batchSender']
         );
     }
 

--- a/Transport/GpsConfigurationResolver.php
+++ b/Transport/GpsConfigurationResolver.php
@@ -184,7 +184,7 @@ final class GpsConfigurationResolver implements GpsConfigurationResolverInterfac
             )
             ->setDefault('compress_message_body', false)
             ->setAllowedTypes('compress_message_body', 'bool')
-            ->setDefault('batch', [])
+            ->setDefault('batch', ['enabled' => true])
             ->setAllowedTypes('batch', 'array')
             ->setNormalizer('batch', $batchOptionsNormalizer)
             ->setAllowedTypes('client_config', 'array')

--- a/Transport/GpsTransport.php
+++ b/Transport/GpsTransport.php
@@ -93,7 +93,7 @@ final class GpsTransport implements TransportInterface, SetupableTransportInterf
             return $this->sender;
         }
 
-        $this->sender = $this->gpsConfiguration->isBatchingEnabled()
+        $this->sender = $this->gpsConfiguration->isBatchSenderEnabled()
             ? new GpsBatchSender($this->pubSubClient, $this->gpsConfiguration, $this->serializer)
             : new GpsSender($this->pubSubClient, $this->gpsConfiguration, $this->serializer);
 

--- a/Transport/GpsTransport.php
+++ b/Transport/GpsTransport.php
@@ -8,6 +8,7 @@ use Google\Cloud\PubSub\PubSubClient;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 use Symfony\Component\Messenger\Transport\SetupableTransportInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 
@@ -20,7 +21,7 @@ final class GpsTransport implements TransportInterface, SetupableTransportInterf
     private GpsConfigurationInterface $gpsConfiguration;
     private SerializerInterface $serializer;
     private GpsReceiver $receiver;
-    private GpsBatchSender $sender;
+    private SenderInterface $sender;
     private LoggerInterface $logger;
 
     public function __construct(
@@ -85,14 +86,16 @@ final class GpsTransport implements TransportInterface, SetupableTransportInterf
         return $this->receiver;
     }
 
-    public function getSender(): GpsBatchSender
+    public function getSender(): SenderInterface
     {
         /** @psalm-suppress RedundantPropertyInitializationCheck */
         if (isset($this->sender)) {
             return $this->sender;
         }
 
-        $this->sender = new GpsBatchSender($this->pubSubClient, $this->gpsConfiguration, $this->serializer);
+        $this->sender = $this->gpsConfiguration->isBatchingEnabled()
+            ? new GpsBatchSender($this->pubSubClient, $this->gpsConfiguration, $this->serializer)
+            : new GpsSender($this->pubSubClient, $this->gpsConfiguration, $this->serializer);
 
         return $this->sender;
     }


### PR DESCRIPTION
## 🎯 Summary

Added configurable batch options for the GPS Transport and enables switching between batch and non-batch senders.

## 📝 Changes

### New Features
- **Batch Configuration**: New `batchSender` configuration option for GPS Transport with the following parameters:
  - `enabled` (bool): Enable/disable batching (default: `true`)
  - `batchSize` (int): Number of messages per batch (default: 100)
  - `callPeriod` (float): Time interval for batch calls (default: 0.1)

## ✅ Backward Compatibility

 - All changes are backward compatible
 - Batching is enabled by default (enabled: true)
 - Existing configurations continue to work without modifications

## 🔧 Usage

```yaml
# config/packages/messenger.yaml
framework:
    messenger:
        transports:
            gps:
                dsn: 'gps://default'
                options:
                    batchSender:
                        enabled: true
                        batchSize: 100
                        callPeriod: 0.1
